### PR TITLE
Create transcode directory if it does not exist to prevent failure

### DIFF
--- a/src/imdl/torrent.rs
+++ b/src/imdl/torrent.rs
@@ -25,6 +25,10 @@ pub async fn create_torrent(
     if output.status.success() {
         Ok(())
     } else {
-        Err(anyhow::anyhow!("Failed to create torrent"))
+        let output_info = match String::from_utf8(output.stderr) {
+            Ok(string) => string,
+            Err(..) => "<failed to load command output>".to_string()
+        };
+        Err(anyhow::anyhow!(format!("Failed to create torrent: {}", output_info)))
     }
 }

--- a/src/transcode/transcode.rs
+++ b/src/transcode/transcode.rs
@@ -52,7 +52,7 @@ pub async fn transcode_release(
         }
     }
 
-    fs::create_dir(&output_dir).await?;
+    fs::create_dir_all(&output_dir).await?;
 
     let paths = get_all_files_with_extension(&flac_dir, ".flac").await?;
 


### PR DESCRIPTION
Right now if there is no transcode directory, it will fail with an abstract message "Error: No such file or directory (os error 2)" #8

This PR will fix this issue by automatically creating the transcode directory if it doesn't exist

I also improved the error message if it fails to create a torrent.