### PR TITLE
fix(transcode): fix duplicate transcode path for extra files

### DIFF
--- a/src/command/transcode.rs
+++ b/src/command/transcode.rs
@@ -475,9 +475,13 @@ async fn handle_url(
             )
             .await?;
 
-            let transcode_folder_path = output_dir.join(&folder_path);
+            let transcode_folder_path = if output_dir.eq(&folder_path) {
+                &folder_path
+            } else {
+                &output_dir.join(&folder_path)
+            };
 
-            copy_other_allowed_files(&flac_path_clone, &flac_path_clone, &transcode_folder_path)
+            copy_other_allowed_files(&flac_path_clone, &flac_path_clone, transcode_folder_path)
                 .await?;
 
             return Ok::<(PathBuf, ReleaseType, String), anyhow::Error>((


### PR DESCRIPTION
Fixes duplicate destination path for extra files (cover images, txt files).

For example:
If the image file in the original content directory is `./content/various artists - songs for the amazon vol. 1/cover.png` (and the transcode directory is `./transcoded`), `transcode_folder_path` becomes `./transcoded/Various Artists - songs for the amazon vol. 1 [2020] (WEB - FLAC)/./transcoded/Various Artists - songs for the amazon vol. 1 [2020] (WEB - FLAC)` because `output_dir` and `folder_path` are the same.

Therefore, the destination path for the cover image ends up as `./transcoded/Various Artists - songs for the amazon vol. 1 [2020] (WEB - FLAC)/./transcoded/Various Artists - songs for the amazon vol. 1 [2020] (WEB - FLAC)/cover.png/cover.png`, when it should be `./transcoded/Various Artists - songs for the amazon vol. 1 [2020] (WEB - FLAC)/cover.png`